### PR TITLE
COMP: CMake, add INCLUDE_DIRS for swig to work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,27 +49,16 @@ set(_proxTV_lib "")
 if(ITK_USE_SYSTEM_proxTV)
   find_package(proxTV REQUIRED CONFIG)
   set(_proxTV_lib proxTV::proxTV)
-
-  # When this module is loaded by an app, load proxTV too.
-  set(${PROJECT_NAME}_EXPORT_CODE_INSTALL
-"${${PROJECT_NAME}_EXPORT_CODE_INSTALL}
-set(proxTV_DIR \"${proxTV_DIR}\")
-find_package(proxTV REQUIRED CONFIG)
-")
+  set(proxTV_DIR_INSTALL ${proxTV_DIR})
+  set(proxTV_DIR_BUILD ${proxTV_DIR})
+  # It is only needed to EXPORT_CODE_BUILD when using external proxTV
   set(${PROJECT_NAME}_EXPORT_CODE_BUILD
 "${${PROJECT_NAME}_EXPORT_CODE_BUILD}
 if(NOT ITK_BINARY_DIR)
-  set(proxTV_DIR \"${proxTV_DIR}\")
+  set(proxTV_DIR \"${proxTV_DIR_BUILD}\")
   find_package(proxTV REQUIRED CONFIG)
 endif()
 ")
-
-  if(NOT ITK_SOURCE_DIR)
-    include(ITKModuleExternal)
-  else()
-    itk_module_impl()
-  endif()
-
 else(ITK_USE_SYSTEM_proxTV) # build proxTV here with the selected Eigen3
   # Build proxTV with C++11
   if(NOT CMAKE_CXX_STANDARD)
@@ -81,12 +70,9 @@ else(ITK_USE_SYSTEM_proxTV) # build proxTV here with the selected Eigen3
   if(NOT CMAKE_CXX_EXTENSIONS)
     set(CMAKE_CXX_EXTENSIONS OFF)
   endif()
-  set(proxTV_EPNAME ${PROJECT_NAME}_ExtProject)
-  set(lib_dir ${CMAKE_CURRENT_BINARY_DIR}/${proxTV_EPNAME}-build/lib)
 
   set(proxTV_GIT_REPOSITORY "https://github.com/phcerdan/proxTV.git")
   set(proxTV_GIT_TAG "use_eigen")
-  # itk_download_attempt_check(${proxTV_EPNAME})
   FetchContent_Declare(
     proxtv_fetch
     GIT_REPOSITORY ${proxTV_GIT_REPOSITORY}
@@ -101,16 +87,27 @@ else(ITK_USE_SYSTEM_proxTV) # build proxTV here with the selected Eigen3
   # proxTV will generate a target proxTV::proxTV when using find_package,
   # or a library proxTV when using add_subdirectory
   set(_proxTV_lib proxTV) # proxTV generated in subdirectory
-
-  # Populate module variables
-  if(NOT ITK_SOURCE_DIR)
-    include(ITKModuleExternal)
-  else()
-    set(ITK_DIR ${CMAKE_BINARY_DIR})
-    itk_module_impl()
-  endif()
-
+  set(proxTV_DIR_INSTALL "\${ITK_MODULES_DIR}/../proxTV")
 endif(ITK_USE_SYSTEM_proxTV)
+
+# When this module is loaded by an app, load proxTV too.
+set(${PROJECT_NAME}_EXPORT_CODE_INSTALL
+"${${PROJECT_NAME}_EXPORT_CODE_INSTALL}
+set(proxTV_DIR \"${proxTV_DIR_INSTALL}\")
+find_package(proxTV REQUIRED CONFIG)
+")
+
+# SWIG (wrapping) requires INCLUDE_DIRS
+get_target_property(proxTV_INCLUDE_DIRS ${_proxTV_lib} INTERFACE_INCLUDE_DIRECTORIES)
+set(TotalVariation_INCLUDE_DIRS ${proxTV_INCLUDE_DIRS})
+
+# Populate module variables
+if(NOT ITK_SOURCE_DIR)
+  include(ITKModuleExternal)
+else()
+  set(ITK_DIR ${CMAKE_BINARY_DIR})
+  itk_module_impl()
+endif()
 
 if(NOT ITK_USE_SYSTEM_proxTV)
   set(arg_module_target "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ set(TotalVariation_LIBRARIES TotalVariation)
 
 set(${PROJECT_NAME}_THIRD_PARTY 1)
 
+include(itk-module-init.cmake)
+
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)
   list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
@@ -13,11 +15,7 @@ endif()
 include(CMakeParseArguments)
 include(FetchContent)
 
-# This be here, just in case, in the future we switch to use lapack instead of eigen for proxTV.
-option(TotalVariation_proxTV_USE_EIGEN "proxTV in TotalVariation uses EIGEN" ON)
-# Add the option to use Eigen3 from outside, or the internal Eigen3 install in ITK.
-option(ITK_USE_SYSTEM_EIGEN "Uses external Eigen3, when OFF uses the internal Eigen3 from ITK." OFF)
-
+message(STATUS "TotalVariation_proxTV_USE_EIGEN: ${TotalVariation_proxTV_USE_EIGEN}")
 if(TotalVariation_proxTV_USE_EIGEN)
   if(NOT ITK_USE_SYSTEM_EIGEN)
     # Set Eigen3_DIR to the internal ITKEigen3 module.
@@ -43,7 +41,7 @@ else()
   set(proxTV_USE_LAPACK 1)
 endif()
 
-# _proxTV_lib will have `proxTV::proxTV` when find_package, and `proxTV` when add_subdirectory(proxTV_folder)
+# _proxTV_lib will be `proxTV::proxTV` when find_package, and `proxTV` when add_subdirectory(proxTV_folder)
 set(_proxTV_lib "")
 # if proxTV is built elsewhere
 if(ITK_USE_SYSTEM_proxTV)
@@ -99,7 +97,14 @@ find_package(proxTV REQUIRED CONFIG)
 
 # SWIG (wrapping) requires INCLUDE_DIRS
 get_target_property(proxTV_INCLUDE_DIRS ${_proxTV_lib} INTERFACE_INCLUDE_DIRECTORIES)
-set(TotalVariation_INCLUDE_DIRS ${proxTV_INCLUDE_DIRS})
+string(REGEX REPLACE
+  ".*BUILD_INTERFACE:(.*/proxtv_fetch-build/src/include).*"
+  "\\1"
+  proxTV_INCLUDE_DIRS_STRIP
+  ${proxTV_INCLUDE_DIRS})
+message(STATUS "proxTV_INCLUDE_DIRS: ${proxTV_INCLUDE_DIRS}")
+message(STATUS "proxTV_INCLUDE_DIRS_STRIP: ${proxTV_INCLUDE_DIRS_STRIP}")
+set(TotalVariation_INCLUDE_DIRS ${proxTV_INCLUDE_DIRS_STRIP})
 
 # Populate module variables
 if(NOT ITK_SOURCE_DIR)
@@ -109,11 +114,14 @@ else()
   itk_module_impl()
 endif()
 
+
 if(NOT ITK_USE_SYSTEM_proxTV)
   set(arg_module_target "")
   if(CMAKE_VERSION VERSION_LESS 3.13)
     # Hits lack of feature: install TARGETS given target "proxTV" which does not exist in this directory.
+    # Remote Modules do not have to support installing anyway.
     list(APPEND arg_module_target "NO_INSTALL")
   endif()
+  # Add the proxTV library to Modules/Targets/TotalVariationTargets.cmake
   itk_module_target(${_proxTV_lib} ${arg_module_target})
 endif()

--- a/itk-module-init.cmake
+++ b/itk-module-init.cmake
@@ -1,0 +1,13 @@
+option(ITK_USE_SYSTEM_proxTV "Use external proxTV" OFF)
+mark_as_advanced(ITK_USE_SYSTEM_proxTV)
+
+option(ITK_USE_SYSTEM_EIGEN "Use External Eigen3" OFF)
+mark_as_advanced(ITK_USE_SYSTEM_EIGEN)
+
+# In case in the future we switch to use lapack instead of eigen for proxTV.
+option(TotalVariation_proxTV_USE_EIGEN "proxTV in TotalVariation uses EIGEN" ON)
+mark_as_advanced(TotalVariation_proxTV_USE_EIGEN)
+
+if(ITK_USE_SYSTEM_proxTV)
+  find_package(proxTV REQUIRED CONFIG)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,5 +3,11 @@ set(TotalVariation_SRCS
   )
 
 itk_module_add_library(TotalVariation ${TotalVariation_SRCS})
-# add_dependencies(TotalVariation ${_proxTV_lib})
+# TODO: Remove debug messages
+message(STATUS "proxTV_lib: ${_proxTV_lib}")
+if(TARGET ${_proxTV_lib})
+  message(STATUS "proxTV_lib: ${_proxTV_lib} TARGET EXISTS")
+else()
+  message(STATUS "proxTV_lib: ${_proxTV_lib} TARGET DOES NOT EXISTS")
+endif()
 target_link_libraries(TotalVariation PUBLIC ${_proxTV_lib})


### PR DESCRIPTION
WIP: Fix TotalVariation_INCLUDE_DIRS

Add itk-module-init.cmake
WIP: Remove debug CMake messages

SWIG is not reading the TotalVariationTargets.cmake file, where proxTV
library is set, with include dirs, interface libraries and compile
definitions.
This creates erorrs, the first sign is missing the INCLUDE_DIRSs.
(TVopt.h not found).
This can be solved hacking the INCLUDE_DIRS of the ITK Module TotalVariation_INCLUDE_DIRS.

Once that's fixed, the next error is missing mex.h file, this is because
the compile definition NO_MATLAB is not applied.

In Eigen3 I faced the same problems, but because it is header only,
fixing INCLUDE_DIRS and adding the compile definitions in the
Eigen3-ITK Header (itkEigen3.h) was enough.

In this case, the compile definitions of proxTV (NO_MATLAB, USE_LAPACK=0)
are ignored.

