### PR TITLE
BUG: Add TotalVariation_EXPORT to fix windows linking

### DIFF
--- a/include/itkProxTVImageFilter.h
+++ b/include/itkProxTVImageFilter.h
@@ -19,6 +19,7 @@
 #define itkProxTVImageFilter_h
 
 #include "itkImageToImageFilter.h"
+#include "TotalVariationExport.h"
 #include "TVopt.h"
 
 namespace itk
@@ -35,7 +36,7 @@ namespace itk
  *
  */
 template< typename TInputImage, typename TOutputImage >
-class ProxTVImageFilter: public ImageToImageFilter< TInputImage, TOutputImage >
+class TotalVariation_EXPORT ProxTVImageFilter: public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
   ITK_DISALLOW_COPY_AND_ASSIGN(ProxTVImageFilter);


### PR DESCRIPTION
Tries to solve problem in windows:
```
cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --intdir=test\CMakeFiles\TotalVariationTestDriver.dir --manifests  -- C:\PROGRA~2\MICROS~1\2017\ENTERP~1\VC\Tools\MSVC\1416~1.270\bin\Hostx64\x64\link.exe /nologo test\CMakeFiles\TotalVariationTestDriver.dir\TotalVariationTestDriver.cxx.obj test\CMakeFiles\TotalVariationTestDriver.dir\itkProxTVImageFilterTest.cxx.obj  /out:D:\a\1\ITK-build\bin\TotalVariationTestDriver.exe /implib:D:\a\1\ITK-build\lib\TotalVariationTestDriver.lib /pdb:D:\a\1\ITK-build\bin\TotalVariationTestDriver.pdb /version:0.0  /machine:x64  /INCREMENTAL:NO  /subsystem:console  D:\a\1\ITK-build\lib\ITKMetaIO-5.0.lib D:\a\1\ITK-build\lib\ITKTestKernel-5.0.lib D:\a\1\ITK-build\lib\itkTotalVariation-5.0.lib _deps\proxtv_fetch-build\src\itkproxTV-5.0.lib D:\a\1\ITK-build\lib\ITKTestKernel-5.0.lib D:\a\1\ITK-build\lib\ITKIOBMP-5.0.lib D:\a\1\ITK-build\lib\ITKIOGDCM-5.0.lib D:\a\1\ITK-build\lib\itkgdcmMSFF-5.0.lib D:\a\1\ITK-build\lib\itkgdcmDICT-5.0.lib D:\a\1\ITK-build\lib\itkgdcmIOD-5.0.lib D:\a\1\ITK-build\lib\itkgdcmDSED-5.0.lib D:\a\1\ITK-build\lib\itkgdcmCommon-5.0.lib crypt32.lib D:\a\1\ITK-build\lib\ITKEXPAT-5.0.lib D:\a\1\ITK-build\lib\itkgdcmjpeg8-5.0.lib D:\a\1\ITK-build\lib\itkgdcmjpeg12-5.0.lib D:\a\1\ITK-build\lib\itkgdcmjpeg16-5.0.lib D:\a\1\ITK-build\lib\itkgdcmopenjp2-5.0.lib D:\a\1\ITK-build\lib\itkgdcmcharls-5.0.lib rpcrt4.lib D:\a\1\ITK-build\lib\ITKIOGIPL-5.0.lib D:\a\1\ITK-build\lib\ITKIOJPEG-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshBYU-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshFreeSurfer-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshGifti-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshOBJ-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshOFF-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshVTK-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshBase-5.0.lib D:\a\1\ITK-build\lib\ITKMesh-5.0.lib D:\a\1\ITK-build\lib\ITKQuadEdgeMesh-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeta-5.0.lib D:\a\1\ITK-build\lib\ITKMetaIO-5.0.lib D:\a\1\ITK-build\lib\itkzlib-5.0.lib comctl32.lib wsock32.lib D:\a\1\ITK-build\lib\ITKIONIFTI-5.0.lib D:\a\1\ITK-build\lib\ITKTransform-5.0.lib D:\a\1\ITK-build\lib\ITKIONRRD-5.0.lib D:\a\1\ITK-build\lib\ITKIOPNG-5.0.lib D:\a\1\ITK-build\lib\ITKIOTIFF-5.0.lib D:\a\1\ITK-build\lib\ITKIOImageBase-5.0.lib D:\a\1\ITK-build\lib\ITKIOVTK-5.0.lib D:\a\1\ITK-build\lib\ITKCommon-5.0.lib D:\a\1\ITK-build\lib\itksys-5.0.lib ws2_32.lib Psapi.lib D:\a\1\ITK-build\lib\ITKVNLInstantiation-5.0.lib D:\a\1\ITK-build\lib\itkvnl_algo-5.0.lib D:\a\1\ITK-build\lib\itkvnl-5.0.lib D:\a\1\ITK-build\lib\itkv3p_netlib-5.0.lib D:\a\1\ITK-build\lib\itknetlib-5.0.lib D:\a\1\ITK-build\lib\itkvcl-5.0.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
LINK: command "C:\PROGRA~2\MICROS~1\2017\ENTERP~1\VC\Tools\MSVC\1416~1.270\bin\Hostx64\x64\link.exe /nologo test\CMakeFiles\TotalVariationTestDriver.dir\TotalVariationTestDriver.cxx.obj test\CMakeFiles\TotalVariationTestDriver.dir\itkProxTVImageFilterTest.cxx.obj /out:D:\a\1\ITK-build\bin\TotalVariationTestDriver.exe /implib:D:\a\1\ITK-build\lib\TotalVariationTestDriver.lib /pdb:D:\a\1\ITK-build\bin\TotalVariationTestDriver.pdb /version:0.0 /machine:x64 /INCREMENTAL:NO /subsystem:console D:\a\1\ITK-build\lib\ITKMetaIO-5.0.lib D:\a\1\ITK-build\lib\ITKTestKernel-5.0.lib D:\a\1\ITK-build\lib\itkTotalVariation-5.0.lib _deps\proxtv_fetch-build\src\itkproxTV-5.0.lib D:\a\1\ITK-build\lib\ITKTestKernel-5.0.lib D:\a\1\ITK-build\lib\ITKIOBMP-5.0.lib D:\a\1\ITK-build\lib\ITKIOGDCM-5.0.lib D:\a\1\ITK-build\lib\itkgdcmMSFF-5.0.lib D:\a\1\ITK-build\lib\itkgdcmDICT-5.0.lib D:\a\1\ITK-build\lib\itkgdcmIOD-5.0.lib D:\a\1\ITK-build\lib\itkgdcmDSED-5.0.lib D:\a\1\ITK-build\lib\itkgdcmCommon-5.0.lib crypt32.lib D:\a\1\ITK-build\lib\ITKEXPAT-5.0.lib D:\a\1\ITK-build\lib\itkgdcmjpeg8-5.0.lib D:\a\1\ITK-build\lib\itkgdcmjpeg12-5.0.lib D:\a\1\ITK-build\lib\itkgdcmjpeg16-5.0.lib D:\a\1\ITK-build\lib\itkgdcmopenjp2-5.0.lib D:\a\1\ITK-build\lib\itkgdcmcharls-5.0.lib rpcrt4.lib D:\a\1\ITK-build\lib\ITKIOGIPL-5.0.lib D:\a\1\ITK-build\lib\ITKIOJPEG-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshBYU-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshFreeSurfer-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshGifti-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshOBJ-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshOFF-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshVTK-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeshBase-5.0.lib D:\a\1\ITK-build\lib\ITKMesh-5.0.lib D:\a\1\ITK-build\lib\ITKQuadEdgeMesh-5.0.lib D:\a\1\ITK-build\lib\ITKIOMeta-5.0.lib D:\a\1\ITK-build\lib\ITKMetaIO-5.0.lib D:\a\1\ITK-build\lib\itkzlib-5.0.lib comctl32.lib wsock32.lib D:\a\1\ITK-build\lib\ITKIONIFTI-5.0.lib D:\a\1\ITK-build\lib\ITKTransform-5.0.lib D:\a\1\ITK-build\lib\ITKIONRRD-5.0.lib D:\a\1\ITK-build\lib\ITKIOPNG-5.0.lib D:\a\1\ITK-build\lib\ITKIOTIFF-5.0.lib D:\a\1\ITK-build\lib\ITKIOImageBase-5.0.lib D:\a\1\ITK-build\lib\ITKIOVTK-5.0.lib D:\a\1\ITK-build\lib\ITKCommon-5.0.lib D:\a\1\ITK-build\lib\itksys-5.0.lib ws2_32.lib Psapi.lib D:\a\1\ITK-build\lib\ITKVNLInstantiation-5.0.lib D:\a\1\ITK-build\lib\itkvnl_algo-5.0.lib D:\a\1\ITK-build\lib\itkvnl-5.0.lib D:\a\1\ITK-build\lib\itkv3p_netlib-5.0.lib D:\a\1\ITK-build\lib\itknetlib-5.0.lib D:\a\1\ITK-build\lib\itkvcl-5.0.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib /MANIFEST /MANIFESTFILE:D:\a\1\ITK-build\bin\TotalVariationTestDriver.exe.manifest" failed (exit code 1181) with the following output:

LINK : fatal error LNK1181: cannot open input file 'D:\a\1\ITK-build\lib\itkTotalVariation-5.0.lib'


```