### PR TITLE
DOC: Fix License badge link target

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ ITKTotalVariation
     :alt: PyPI
 
 .. image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
-    :target: https://github.com/InsightSoftwareConsortium/ITKTotalVariation/blob/master/LICENSE)
+    :target: https://github.com/InsightSoftwareConsortium/ITKTotalVariation/blob/master/LICENSE
     :alt: License
 
 


### PR DESCRIPTION
Fix License badge link target.

A closing bracket slipped in commit 9998988.