### PR TITLE
BUG: Run Window Python package build as administrator

### DIFF
--- a/test/azure-pipelines.yml
+++ b/test/azure-pipelines.yml
@@ -210,7 +210,7 @@ jobs:
       set ITK_PACKAGE_VERSION=$(ITKPythonGitTag)
       set CC=cl.exe
       set CXX=cl.exe
-      powershell.exe -file .\windows-download-cache-and-build-module-wheels.ps1
+      Start-Process powershell.exe -Verb Runas -ArgumentList "-File .\windows-download-cache-and-build-module-wheels.ps1"
     displayName: 'Build Python packages'
 
   - task: PublishPipelineArtifact@0


### PR DESCRIPTION
Attempt to work around error:

  removing '_skbuild\win-amd64-3.5\cmake-install'
  removing '_skbuild\win-amd64-3.5\cmake-build'
  error: [WinError 5] Access is denied:
  '_skbuild\\win-amd64-3.5\\cmake-build\\_deps\\proxtv_fetch-src\\.git\\objects\\pack\\pack-e2e9289da314c7416a62936045dee9c6bdf7736a.idx'
  SCRIPT_DIR: C:\P\IPP\scripts%