### PR TITLE
Revert "BUG: Run Window Python package build as administrator"

### DIFF
--- a/test/azure-pipelines.yml
+++ b/test/azure-pipelines.yml
@@ -210,7 +210,7 @@ jobs:
       set ITK_PACKAGE_VERSION=$(ITKPythonGitTag)
       set CC=cl.exe
       set CXX=cl.exe
-      Start-Process powershell.exe -Verb Runas -ArgumentList "-File .\windows-download-cache-and-build-module-wheels.ps1"
+      powershell.exe -file .\windows-download-cache-and-build-module-wheels.ps1
     displayName: 'Build Python packages'
 
   - task: PublishPipelineArtifact@0


### PR DESCRIPTION
This reverts commit 85d019eb79a89a9b1cf9bb897f290a3cfcaafeee.

This commit did not address the permission error in Azure Pipelines and
newer pipeline builds are throwing:

  'Start-Process' is not recognized as an internal or external command,