### PR TITLE
COMP: Ensure proxTV dependencies are found when building against ITK build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,13 @@ else(ITK_USE_SYSTEM_proxTV) # build proxTV here with the selected Eigen3
   # or a library proxTV when using add_subdirectory
   set(_proxTV_lib proxTV) # proxTV generated in subdirectory
   set(proxTV_DIR_INSTALL "\${ITK_MODULES_DIR}/../proxTV")
+
+  # When this module is loaded by an app, load proxTV too.
+  set(${PROJECT_NAME}_EXPORT_CODE_BUILD
+"${${PROJECT_NAME}_EXPORT_CODE_BUILD}
+set(proxTV_DIR \"${proxtv_fetch_BINARY_DIR}\")
+find_package(proxTV REQUIRED CONFIG)
+")
 endif(ITK_USE_SYSTEM_proxTV)
 
 # When this module is loaded by an app, load proxTV too.


### PR DESCRIPTION

This issue was discovered in the following context:
* ITK configured with Module_TotalVariation:BOOL=ON
* OpenMP installed on the system: This means proxTV depends on OpenMP
* ITK used from a build tree

Error reported was the following:

```
  CMake Error at /path/to/project-build/SlicerExecutionModel-build/CMake/SEMMacroBuildCLI.cmake:159 (add_executable):
    Target "AwesomeModule" links to target "OpenMP::OpenMP_CXX" but the
    target was not found.  Perhaps a find_package() call is missing for an
    IMPORTED target, or an ALIAS target is missing?
  Call Stack (most recent call first):
    Modules/AwesomeModule/CMakeLists.txt:46 (SEMMacroBuildCLI)
````