### PR TITLE
STYLE: Remove CMake-language block-end command arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(NOT ITK_BINARY_DIR)
   find_package(proxTV REQUIRED CONFIG)
 endif()
 ")
-else(ITK_USE_SYSTEM_proxTV) # build proxTV here with the selected Eigen3
+else() # build proxTV here with the selected Eigen3
   # Build proxTV with C++11
   if(NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 11)
@@ -104,7 +104,7 @@ else(ITK_USE_SYSTEM_proxTV) # build proxTV here with the selected Eigen3
 set(proxTV_DIR \"${proxtv_fetch_BINARY_DIR}\")
 find_package(proxTV REQUIRED CONFIG)
 ")
-endif(ITK_USE_SYSTEM_proxTV)
+endif()
 
 # When this module is loaded by an app, load proxTV too.
 set(${PROJECT_NAME}_EXPORT_CODE_INSTALL


### PR DESCRIPTION
Ancient versions of CMake required else(), endif(), and similar block
termination commands to have arguments matching the command starting the block.
This is no longer the preferred style.