### PR TITLE
COMP: fixing unused variable warning

### DIFF
--- a/include/itkProxTVImageFilter.hxx
+++ b/include/itkProxTVImageFilter.hxx
@@ -53,7 +53,6 @@ ProxTVImageFilter<TInputImage, TOutputImage>::GenerateData()
   this->AllocateOutputs();
   OutputImageType *      output = this->GetOutput();
   const InputImageType * input = this->GetInput();
-  using InputRegionType = typename InputImageType::RegionType;
   auto regionSize = output->GetLargestPossibleRegion().GetSize();
 
   using DoubleImageType = itk::Image<double, ImageDimension>;
@@ -80,17 +79,17 @@ ProxTVImageFilter<TInputImage, TOutputImage>::GenerateData()
     // int DR2_TV(size_t M (rows), size_t N (cols), double*inputProxTV (image),
     // double W1, double W2, double norm1, double norm2, double*s, int nThreads,
     // int maxit, double* info);
-    int r = DR2_TV(regionSize[0],
-                   regionSize[1],
-                   const_cast<double *>(inputProxTV),
-                   m_Weights[0],
-                   m_Weights[1],
-                   m_Norms[0],
-                   m_Norms[1],
-                   resultProxTV,
-                   nThreads,
-                   maxIters,
-                   info);
+    std::ignore = DR2_TV(regionSize[0],
+                         regionSize[1],
+                         const_cast<double *>(inputProxTV),
+                         m_Weights[0],
+                         m_Weights[1],
+                         m_Norms[0],
+                         m_Norms[1],
+                         resultProxTV,
+                         nThreads,
+                         maxIters,
+                         info);
   }
   else
   {
@@ -107,17 +106,17 @@ ProxTVImageFilter<TInputImage, TOutputImage>::GenerateData()
       elements[i] = regionSize[i];
       dims[i] = i + 1;
     }
-    int r = PD_TV(const_cast<double *>(inputProxTV),
-                  weights,
-                  norms,
-                  dims /* Apply weights in these dims */,
-                  resultProxTV,
-                  info,
-                  elements,
-                  ImageDimension /* Number of penalty terms */,
-                  ImageDimension /* Number of dimensions */,
-                  nThreads,
-                  maxIters);
+    std::ignore = PD_TV(const_cast<double *>(inputProxTV),
+                        weights,
+                        norms,
+                        dims /* Apply weights in these dims */,
+                        resultProxTV,
+                        info,
+                        elements,
+                        ImageDimension /* Number of penalty terms */,
+                        ImageDimension /* Number of dimensions */,
+                        nThreads,
+                        maxIters);
   }
 
   using CastDoubleToOutputImageFilter = itk::CastImageFilter<DoubleImageType, OutputImageType>;


### PR DESCRIPTION
/Users/Shared/IMF_SDK/superbuild/ITK-5.1/Source/ITK/Modules/Remote/TotalVariation/include/itkProxTVImageFilter.hxx:83:9: warning: unused variable 'r' [-Wunused-variable]

Discovered by @imikejackson.