### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_AND_MOVE

### DIFF
--- a/include/itkProxTVImageFilter.h
+++ b/include/itkProxTVImageFilter.h
@@ -38,7 +38,7 @@ template <typename TInputImage, typename TOutputImage>
 class ProxTVImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ProxTVImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ProxTVImageFilter);
 
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
 


### PR DESCRIPTION
This PR fixes changes made in #2053. Essentially,` ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will only be used if `ITK_FUTURE_LEGACY_REMOVE`=`OFF`.